### PR TITLE
Mejora de aspecto de ratio y cambio en el CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2022-06-19
+## Improved
+-   Relación de aspecto de imagen correcta
+
 ## [1.0.0] - 2022-05-26
 
 ### Added

--- a/src/views/_product-card.html
+++ b/src/views/_product-card.html
@@ -5,6 +5,7 @@
             src="https://via.placeholder.com/150"
             alt="foto de un {{ product.name }}"
             width="150px"
+            height="150"
             class="rounded"
             loading="async"
         />


### PR DESCRIPTION
Se modificó al aspecto de ratio natural de la imagen y se agregó dicha mejora en el CHANGELOG.

Dentro del lighthouse, en el área de Best Practices, se incrementó el valor de 83 a 92. Dentro del minScore assertion, hubo un incremento, pasando de 0,84 a 0,89.